### PR TITLE
Add option to display story owners

### DIFF
--- a/exe/get-story-info-from-id
+++ b/exe/get-story-info-from-id
@@ -3,15 +3,29 @@
 require 'open-uri'
 require 'json'
 
-def get_story_info(story_id)
+BASE_URL = "https://www.pivotaltracker.com/services/v5/stories/"
+
+def get_story_info(story_id, flags = [])
   return nil if story_id.empty?
 
   begin
-    open("https://www.pivotaltracker.com/services/v5/stories/#{story_id}", 'X-TrackerToken' => ENV['PIVOTAL_TRACKER_API_TOKEN']).read
+    include_owner_names = flags.any? { |f| f == '--owners' || f == '-O' }
+    url = BASE_URL + "#{story_id}" + "/#{include_owner_names ? '?fields=:default,owners' : ''}"
+    open(
+      url,
+      'X-TrackerToken' => ENV['PIVOTAL_TRACKER_API_TOKEN']
+    ).read
   rescue StandardError => e
     JSON.generate({error: "could not get story info for story #{story_id}: #{e.message}\nstory info may be available at https://www.pivotaltracker.com/story/show/#{story_id}"})
   end
 end
+
+flags = ARGV.reduce([]) do |reduced, a|
+  reduced << a if a.include?('--') || a.include?('-')
+  reduced
+end
+
+flags.each { |f| ARGV.delete f }
 
 stream = ARGV.any? ? ARGV : ARGF
 
@@ -19,12 +33,14 @@ if stream == ARGF && $stdin.tty?
   puts "Usage:\nget-story-info-from-id STORY_ID\n"
   puts " OR\n"
   puts "echo STORY_ID | get-story-info-from-id"
+  puts " OR\n"
+  puts "use --w-owner-names to include owner names"
   exit 1
 end
 
 infos = stream.reduce([]) do |reduced, story_id|
   next reduced unless story_id && story_id =~ /\d+/
-  reduced << get_story_info(story_id.strip)
+  reduced << get_story_info(story_id.strip, flags)
 end
 
 puts infos.join("\n")

--- a/exe/stories-deployed
+++ b/exe/stories-deployed
@@ -4,19 +4,36 @@ require 'json'
 require 'ostruct'
 
 environment_tag = ARGV[0]&.strip
-
 if environment_tag.nil? || environment_tag.empty?
   puts "Usage: stories-deployed ENVIRONMENT"
   exit 1
 end
 
-deployed_story_infos = `story-ids-deployed #{environment_tag} | get-story-info-from-id`
+flags = ARGV.select { |a| a.include?('--') || a.include?('-') }
+deployed_story_infos = `story-ids-deployed #{environment_tag} | get-story-info-from-id #{flags.join(' ')}`
 
 stories_deployed = deployed_story_infos.split("\n").compact.reduce([]) do |reduced, story_info|
   story = OpenStruct.new(JSON.parse(story_info))
 
+  include_owner_names = flags.any? { |f| f == '--owners' || f == '-O' }
+
   reduced << "#{story.error}"
-  reduced << "#{story.name}:\n#{story.url}"
+  reduced << "#{story.name&.strip}:\n#{story.url}"
+
+  if include_owner_names
+    owners = story
+      .owners
+      .compact
+      .map { |o| OpenStruct.new(o).name }
+
+    names_joined = owners.size > 2 ?
+      "#{owners[0..-2].join(',')} and #{owners.last}" :
+      owners.join(' and ')
+
+    reduced << "\nBrought to you by: #{names_joined}"
+  end
+
+  reduced
 end
 
 puts stories_deployed

--- a/lib/pivotoolz/version.rb
+++ b/lib/pivotoolz/version.rb
@@ -1,3 +1,3 @@
 module Pivotoolz
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Pass the `--owners` flag or `-O` to `stories-deployed ENVIRONMENT` command to return a message containing the text "Brought to you by: owner1, owner2" as the last line.