### PR TITLE
Support attachments in slack messages and add formatting options

### DIFF
--- a/exe/get-story-info-from-id
+++ b/exe/get-story-info-from-id
@@ -16,7 +16,12 @@ def get_story_info(story_id, flags = [])
       'X-TrackerToken' => ENV['PIVOTAL_TRACKER_API_TOKEN']
     ).read
   rescue StandardError => e
-    JSON.generate({error: "could not get story info for story #{story_id}: #{e.message}\nstory info may be available at https://www.pivotaltracker.com/story/show/#{story_id}"})
+    story_link = "https://www.pivotaltracker.com/story/show/#{story_id}"
+
+    JSON.generate({
+      error: "Could not get story info for story #{story_id}: #{e.message}\n\nStory info may be available at #{story_link}",
+      story_link: story_link
+    })
   end
 end
 

--- a/exe/post-slack-message
+++ b/exe/post-slack-message
@@ -10,13 +10,16 @@ content = ARGV.empty? ? ARGF.read : StringIO.new(ARGV.join("\n")).read
 exit 0 if content.empty?
 
 begin
-  if attachments = JSON.parse(content)
+  if attachments = JSON.parse(
+    "[#{content.split("\n").slice(1..-1).join(",")}]"
+  )
     begin
       RestClient.post(
         URL,
         payload: {
           username: ENV['SLACKBOT_USERNAME'] || 'slackbot',
           channel: channel,
+          text: content.split("\n")&.first || '',
           attachments: attachments,
           icon_emoji: ":ghost:"
         }.to_json

--- a/exe/post-slack-message
+++ b/exe/post-slack-message
@@ -10,6 +10,27 @@ content = ARGV.empty? ? ARGF.read : StringIO.new(ARGV.join("\n")).read
 exit 0 if content.empty?
 
 begin
+  if attachments = JSON.parse(content)
+    begin
+      RestClient.post(
+        URL,
+        payload: {
+          username: ENV['SLACKBOT_USERNAME'] || 'slackbot',
+          channel: channel,
+          attachments: attachments,
+          icon_emoji: ":ghost:"
+        }.to_json
+      )
+    rescue RestClient::Exceptions => e
+      puts "Error posting to slack #{e.message}:\n#{e.backtrace}"
+    end
+
+    exit 0
+  end
+rescue JSON::ParserError => e
+end
+
+begin
   RestClient.post(
     URL,
     payload: {

--- a/exe/stories-deployed
+++ b/exe/stories-deployed
@@ -10,30 +10,84 @@ if environment_tag.nil? || environment_tag.empty?
 end
 
 flags = ARGV.select { |a| a.include?('--') || a.include?('-') }
+
+include_owners = flags
+  .any? { |f| f == '--owners' || f == '-O' }
+
+format_as_json = flags
+  .any? { |f| f == '--json' || f == '-j' }
+
 deployed_story_infos = `story-ids-deployed #{environment_tag} | get-story-info-from-id #{flags.join(' ')}`
 
-stories_deployed = deployed_story_infos.split("\n").compact.reduce([]) do |reduced, story_info|
-  story = OpenStruct.new(JSON.parse(story_info))
-
-  include_owner_names = flags.any? { |f| f == '--owners' || f == '-O' }
-
-  reduced << "#{story.error}"
-  reduced << "#{story.name&.strip}:\n#{story.url}"
-
-  if include_owner_names
-    owners = story
-      .owners
-      .compact
-      .map { |o| OpenStruct.new(o).name }
-
-    names_joined = owners.size > 2 ?
-      "#{owners[0..-2].join(', ')} and #{owners.last}" :
-      owners.join(' and ')
-
-    reduced << "\nBrought to you by: #{names_joined}"
+def as_json(story, include_owners, flags)
+  if story.error
+    return {
+      title: story.error,
+      title_link: story.story_link
+    }.to_json
   end
 
-  reduced
+  json = {
+    title: story.name&.strip,
+    title_link: story.url,
+    mrkdwn_in: ["text", "pretext", "footer"]
+  }
+
+  if include_owners
+    if flags.include? '--owners-footer'
+      json.merge!(
+        footer: "\n\nBrought to you by: #{story_owner_names(story, flags)}"
+      )
+    else
+      json.merge!(
+        text: "\n\nBrought to you by: #{story_owner_names(story, flags)}"
+      )
+    end
+  end
+
+  json.to_json
 end
+
+def story_owner_names(story, flags)
+  owners = story
+    .owners
+    .compact
+    .map { |o| OpenStruct.new(o).name }
+
+  if flags.include? '--bold-owners'
+    return to_sentence(owners.map { |o| "*#{o}*" })
+  end
+
+  to_sentence(owners)
+end
+
+def to_sentence(array)
+  array.size > 2 ?
+    "#{array[0..-2].join(', ')} and #{array.last}" :
+    array.join(' and ')
+end
+
+stories_deployed = deployed_story_infos
+  .split("\n")
+  .compact
+  .reduce([]) do |reduced, story_info|
+    story = OpenStruct.new(JSON.parse(story_info))
+
+    if format_as_json
+      reduced << as_json(story, include_owners, flags)
+      next reduced
+    end
+
+    reduced << "#{story.error}"
+    next reduced if story.error
+
+    reduced << "#{story.name&.strip}:\n#{story.url}"
+
+    if include_owners
+      reduced << "\nBrought to you by: #{story_owner_names(story, flags)}"
+    end
+
+    reduced
+  end
 
 puts stories_deployed

--- a/lib/pivotoolz/version.rb
+++ b/lib/pivotoolz/version.rb
@@ -1,3 +1,3 @@
 module Pivotoolz
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Post content as attachment if input is JSON.

Add new formatting options that can be enabled via flags:

- `--json` or `-j` - Format story info as slack attachment json

- `--bold-owners` - Wrap owner names in earmuffs (*OWNER_NAME*)

- `--owners-footer` - List owners under `footer` json key for json
  slack attachment format