### PR TITLE
Add the ability to pass in values to append to end of branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,11 +189,19 @@ Be sure to set your `PIVOTAL_TRACKER_API_TOKEN` env variable in your `.bashrc` f
 set your git config user initials like this: `git config --add user.initials af`. Otherwise it
 will take your `git config user.name` or `whoami` information.
 
-Example:
+Example 1:
 ```bash
 pv-git-branch "#111222333"
 ```
-This would create and checkout a new branch: `af/features/building-someting-great-111222333`.
+This would create and checkout a new branch:
+`af/features/building-someting-great-111222333`.
+
+Example 2 (appending values):
+```bash
+pv-git-branch 12345678 version2 backend only
+```
+This would create and checkout a new branch:
+`af/features/building-something-awesome-12345678-version2-backend-only`
 
 If the branch had already been created, the command will automatically check out existing branch.
 

--- a/exe/pv-git-branch
+++ b/exe/pv-git-branch
@@ -2,8 +2,9 @@
 
 require_relative '../lib/pivotoolz/git_branch'
 
-if ARGV.length != 1
+if ARGV.length < 1
   puts "#{GitBranch.usage_message}"
   exit
 end
-puts GitBranch.new.generate(ARGV.first)
+first_arg, *the_rest = ARGV
+puts GitBranch.new.generate(first_arg, the_rest)


### PR DESCRIPTION
I used to have the flexibility to append values to the end of a gernerated
branch name. Recently the interface was improved so there is now only a single
command, but I still like the ability to append those values. For example, if
you have multiple branches for a single story on Pivotal, it is nice to do something like:
```
$ pv-git-branch 123456 backend
aaron+fry/features/allow-pv-git-branch-to-pass-values-123456-backend
$ pv-git-branch 123456 frontend
aaron+fry/features/allow-pv-git-branch-to-pass-values-123456-frontend
```
... or if you have multiple versions of that branch for a single story:
```
$ pv-git-branch 123456 v1 spike
aaron+fry/features/allow-pv-git-branch-to-pass-values-123456-v1-spike
$ pv-git-branch 123456 v2 final
aaron+fry/features/allow-pv-git-branch-to-pass-values-123456-v2-final
```
This is backward compatible, so you can still run the command the old way with
now appending values:
```
$ pv-git-branch 123456
aaron+fry/features/allow-pv-git-branch-to-pass-values-123456
```

[#164945069]