### PR TITLE
Update default STORY_ID_REGEX for Jira story IDs

### DIFF
--- a/exe/jira-story-ids-deployed
+++ b/exe/jira-story-ids-deployed
@@ -17,7 +17,7 @@ end
 commit_message_bodies = `git log --pretty="%h %s" #{commit_range}`.strip
 story_ids = commit_message_bodies.
   # TODO: Make this configurable
-  scan(/#{ENV['STORY_ID_REGEX'] || '[[:alpha:]]+-\d+'}/).
+  scan(/#{ENV['STORY_ID_REGEX'] || '[[:alpha:]]+-\d+|[[\w]]+-\d+'}/).
   flatten.
   compact.
   uniq


### PR DESCRIPTION
Jira Story IDs can contain alphanumeric prefixes
before the first `-`.